### PR TITLE
Add autoformatting for C++ and Python

### DIFF
--- a/.github/workflows/auto-formatting.yml
+++ b/.github/workflows/auto-formatting.yml
@@ -1,0 +1,36 @@
+
+name: Formatting code
+on:
+  push:
+    branches:
+      - master
+jobs:
+  auto_format:
+    # Check if the PR is not from a fork
+    if: github.repository == 'waterlooairlock/User-Interface'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Fix C++ formatting
+        uses: HorstBaerbel/action-clang-format@1.4
+        with:
+          scandir: '.'
+          excludedirs: 'build'
+          extensions: 'c,h,C,H,cpp,hpp,cc,hh,c++,h++,cxx,hxx'
+          #style: 'file' # Use if there is a .clang-format (https://clang.llvm.org/docs/ClangFormatStyleOptions.html)
+      - name: Fix Python Formatting
+        id: autopep8
+        uses: peter-evans/autopep8@v1
+        with:
+          args: --exit-code --recursive --in-place --aggressive .
+      - name: Check for modified files
+        id: git-check
+        run: echo ::set-output name=modified::$(if git diff-index --quiet HEAD --; then echo "false"; else echo "true"; fi)
+      - name: Push changes
+        if: steps.git-check.outputs.modified == 'true'
+        run: |
+          git config --global user.name 'waterlooairlock'
+          git config --global user.email 'Watlockemail@gmail.com'
+          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
+          git commit -am "Automated Formatting Fixes"
+          git push

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.vscode*
 *.code-workspace
 desktop.ini
+**/.pio/*
 
 
 ## VISUAL STUDIO GIT IGNORE PARAMETERS


### PR DESCRIPTION
Add Github Workflow for automatic formatting of C++ and Python code.

Workflow is designed to run only on the master branch. Any pushes to the master (including merged pull requests) will be automatically formatted and commited.